### PR TITLE
update discord and wiki links

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -68,7 +68,7 @@ const Layout = ({ children }) => {
 
                     <li>
                         <a
-                            href="https://github.com/ajayyy/SponsorBlock/wiki/Guidelines"
+                            href="https://wiki.sponsor.ajay.app/w/Guidelines"
                             className="nav-link"
                         >
                             Guidelines
@@ -77,7 +77,7 @@ const Layout = ({ children }) => {
 
                     <li>
                         <a
-                            href="https://github.com/ajayyy/SponsorBlock/wiki/API-Docs"
+                            href="https://wiki.sponsor.ajay.app/w/API_Docs"
                             className="nav-link"
                         >
                             API
@@ -101,7 +101,7 @@ const Layout = ({ children }) => {
 
                     <li>
                         <a
-                            href="https://discord.gg/QnmVMpU"
+                            href="https://discord.gg/SponsorBlock"
                             className="nav-link"
                             title="Discord Invite"
                         >

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -137,8 +137,8 @@ const IndexPage = () => (
 
             <p>
                 Feel free to join this Discord:{" "}
-                <a href="https://discord.gg/QnmVMpU">
-                    https://discord.gg/QnmVMpU
+                <a href="https://discord.gg/SponsorBlock">
+                    https://discord.gg/SponsorBlock
                 </a>
             </p>
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -206,7 +206,7 @@ const IndexPage = () => {
                         <a href="https://sponsor.ajay.app/database">database</a>{" "}
                         can be downloaded by anyone. I want to keep this as open
                         as possible! You can view the docs for the{" "}
-                        <a href="https://github.com/ajayyy/SponsorBlock/wiki/API-Docs">
+                        <a href="https://wiki.sponsor.ajay.app/w/API_Docs">
                             public API here
                         </a>
                         .
@@ -218,7 +218,7 @@ const IndexPage = () => {
 
                     <p className="text-center">
                         Come chat with us on{" "}
-                        <a href="https://discord.gg/QnmVMpU">Discord</a> or{" "}
+                        <a href="https://discord.gg/SponsorBlock">Discord</a> or{" "}
                         <a href="https://matrix.to/#/#sponsor:ajay.app?via=ajay.app&via=matrix.org&via=mozilla.org">
                             Matrix
                         </a>


### PR DESCRIPTION
changed links as per https://github.com/ajayyy/SponsorBlock/pull/917

matrix links were already upgraded, prefer /SponsorBlock discord invite and wiki links moved to new short URLs