### PR TITLE
Avoid non-native interactive elements and Do not use Array index in keys

### DIFF
--- a/src/components/donate.js
+++ b/src/components/donate.js
@@ -1,4 +1,3 @@
-import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 
 import "./donate.scss";
@@ -7,11 +6,9 @@ const donateLink = "https://patreon.com/ajayyy";
 
 const Donate = ({ downloadLink, clear }) => {
     return (
-        <div className="donate-modal-container"
+        <button className="donate-modal-container"
             onClick={(e) => {
-                if (e.target.classList.contains("donate-modal-container")) {
-                    if (clear) clear();
-                }
+                if (clear) clear();
             }}>
             <div className="donate-modal">
                 <div>
@@ -38,9 +35,10 @@ const Donate = ({ downloadLink, clear }) => {
                     </a>
                 </div>
             </div>
-        </div>
+        </button>
     );
 };
+
 
 Donate.propTypes = {
     downloadLink: PropTypes.string.isRequired,

--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -55,9 +55,8 @@ const IndexPage = () => {
         let lastPercentage = 0;
         const piechartCode = data.map((d, index) => {
             const percent = parseFloat(d[1]);
-            const str = `${categoryStatsColors[index]} 0 ${
-                lastPercentage + percent
-            }%`;
+            const str = `${categoryStatsColors[index]} 0 ${lastPercentage + percent
+                }%`;
             lastPercentage += percent;
             return str;
         });
@@ -351,12 +350,11 @@ const IndexPage = () => {
                                 </td>
                             </tr>
                         ) : (
-                            topUsers.map((value, index) => (
+                            topUsers.map((value) => (
                                 <tr
-                                    className={`row--${
-                                        index % 2 ? "odd" : "even"
-                                    }`}
-                                    key={index}
+                                    className={`row--${value.id % 2 ? "odd" : "even"
+                                        }`}
+                                    key={value.id}
                                     onMouseEnter={(_) => {
                                         displayCategoryStats(
                                             value.categoryStats
@@ -367,7 +365,7 @@ const IndexPage = () => {
                                     }}
                                 >
                                     <td className="rank celltype-number">
-                                        {index + 1}.
+                                        {value.id + 1}.
                                     </td>
                                     <td>{value.userName}</td>
                                     <td className="celltype-number has--categorystats">
@@ -398,17 +396,17 @@ const IndexPage = () => {
                             </tr>
                         </thead>
                         <tbody>
-                            {categoryStats.data.map((data, index) => (
+                            {categoryStats.data.map((data) => (
                                 <tr
                                     className={classNames({
                                         dim: data[0] === 0,
                                     })}
                                     style={{
-                                        color: categoryStatsColors[index],
+                                        color: categoryStatsColors[data.id],
                                     }}
-                                    key={index}
+                                    key={data.id}
                                 >
-                                    <td>{categoryStatsTitles[index]}</td>
+                                    <td>{categoryStatsTitles[data.id]}</td>
                                     <td className="celltype-number">
                                         {data[0]}
                                     </td>
@@ -418,6 +416,7 @@ const IndexPage = () => {
                                 </tr>
                             ))}
                         </tbody>
+
                     </table>
                     <div
                         className="categorystats-piechart"


### PR DESCRIPTION
Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element. 
Do not use Array index in keys